### PR TITLE
update JRuby to 1.7.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 sass-maven-plugin
 =================
 
-Maven Plugin to Compile SASS files into CSS. Plugin version 1.0.3 uses jRuby 1.6.8, Compass 0.12.2, and SASS 3.2.6
+Maven Plugin to Compile SASS files into CSS. Plugin version 1.1.2 uses jRuby 1.7.16.1, Compass 1.0.1, and Sass 3.4.9.
 
-See here for more details: http://developer.jasig.org/projects/sass-maven-plugin/1.1.1/plugin-info.html
+See here for more details: http://developer.jasig.org/projects/sass-maven-plugin/1.1.2/plugin-info.html

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jasig.parent</groupId>
         <artifactId>jasig-parent</artifactId>
-        <version>34</version>
+        <version>38</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -12,6 +12,10 @@
     <artifactId>sass-maven-plugin</artifactId>
     <version>1.1.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
+
+    <prerequisites>
+        <maven>2.2.1</maven>
+    </prerequisites>
 
     <name>SASS Compiler Plugin</name>
     <description>Maven Plugin that compiles SASS files</description>
@@ -26,10 +30,10 @@
         <project.build.sourceVersion>1.6</project.build.sourceVersion>
         <project.build.targetVersion>1.6</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compass.version>0.12.2</compass.version>
-        <inotify.version>0.8.8</inotify.version>
-        <fsevent.version>0.9.3</fsevent.version>
-        <jruby.version>1.6.8</jruby.version>
+        <compass.version>1.0.1</compass.version>
+        <inotify.version>0.9.5</inotify.version>
+        <fsevent.version>0.9.4</fsevent.version>
+        <jruby.version>1.7.16.1</jruby.version>
     </properties>
     
     <dependencies>
@@ -41,7 +45,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0.5</version>
+            <version>3.2.3</version>
         </dependency>
         <dependency>
           <groupId>commons-io</groupId>
@@ -51,7 +55,7 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>14.0.1</version>
+          <version>18.0</version>
         </dependency>
 
         <!-- rubygems -->
@@ -103,7 +107,7 @@
                         <reportPlugins combine.children="append">
                             <plugin>
                                 <artifactId>maven-plugin-plugin</artifactId>
-                                <version>2.9</version>
+                                <version>3.2</version>
                             </plugin>
                         </reportPlugins>
                     </configuration>
@@ -140,7 +144,7 @@
             <plugin>
                 <groupId>de.saumya.mojo</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
-                <version>0.29.4</version>
+                <version>1.0.3</version>
                 <executions>
                     <execution>
                         <id>install-gems</id>
@@ -166,7 +170,7 @@
                     <reportPlugins combine.children="append">
                         <plugin>
                             <artifactId>maven-plugin-plugin</artifactId>
-                            <version>2.9</version>
+                            <version>3.2</version>
                         </plugin>
                     </reportPlugins>
                 </configuration>

--- a/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/org/jasig/maven/plugin/sass/AbstractSassMojo.java
@@ -235,8 +235,8 @@ public abstract class AbstractSassMojo extends AbstractMojo {
             sassScript.append("Compass.add_project_configuration \n");
             this.sassOptions.put("load_paths", "Compass.configuration.sass_load_paths");
             // manually specify these paths
-            sassScript.append("Compass::Frameworks.register_directory('jar:'+ File.join(Compass.base_directory, 'frameworks/compass'))\n");
-            sassScript.append("Compass::Frameworks.register_directory('jar:'+ File.join(Compass.base_directory, 'frameworks/blueprint'))\n");
+            sassScript.append("Compass::Frameworks.register_directory(File.join(Compass.base_directory, 'frameworks/compass'))\n");
+            sassScript.append("Compass::Frameworks.register_directory(File.join(Compass.base_directory, 'frameworks/blueprint'))\n");
         }
 
         // Get all template locations from resources and set option 'template_location' and


### PR DESCRIPTION
Also updates some other dependencies:
- guava
- rb-inotify
- maven-plugin-api

and plugins:
- gem-maven-plugin
- maven-plugin-plugin

and require at least maven 2.2.1 to build (which was required implicitly anyway, but lets be clear about it)

close #14
