### PR TITLE
upgrade to JRuby9000

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<compass.version>1.0.3</compass.version>
 		<sass.version>3.4.15</sass.version>
-		<jruby.version>9.0.0.0.pre2</jruby.version>
+		<jruby.version>9.0.0.0.rc1</jruby.version>
 		<maven-libs.version>3.3.3</maven-libs.version>
 		<scss-lint.version>0.40.1</scss-lint.version>
 		<maven.version />

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<compass.version>1.0.3</compass.version>
 		<sass.version>3.4.15</sass.version>
-		<jruby.version>1.7.21</jruby.version>
+		<jruby.version>9.0.0.0.pre1</jruby.version>
 		<maven-libs.version>3.3.3</maven-libs.version>
 		<scss-lint.version>0.40.1</scss-lint.version>
 		<maven.version />

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<compass.version>1.0.3</compass.version>
 		<sass.version>3.4.15</sass.version>
-		<jruby.version>9.0.0.0.pre1</jruby.version>
+		<jruby.version>9.0.0.0.pre2</jruby.version>
 		<maven-libs.version>3.3.3</maven-libs.version>
 		<scss-lint.version>0.40.1</scss-lint.version>
 		<maven.version />

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<compass.version>1.0.3</compass.version>
 		<sass.version>3.4.15</sass.version>
-		<jruby.version>9.0.0.0.rc1</jruby.version>
+		<jruby.version>9.0.0.0.rc2</jruby.version>
 		<maven-libs.version>3.3.3</maven-libs.version>
 		<scss-lint.version>0.40.1</scss-lint.version>
 		<maven.version />


### PR DESCRIPTION
Give JRuby 9.0.0.0. pre-releases aand snapshots a try, see: 
  - [x] [9.0.0.0-pre1](http://jruby.org/2015/01/20/jruby-9-0-0-0-pre1.html)
  - [x] [9.0.0.0-pre2](http://jruby.org/2015/04/28/jruby-9-0-0-0-pre2.html)
  - [x] [9.0.0.0-rc1](http://jruby.org/2015/06/10/jruby-9-0-0-0-rc1.html)
  - [x] [9.0.0.0-rc2](http://jruby.org/2015/07/09/jruby-9-0-0-0-rc2.html)
  - [ ] [9.0.0.0]()

close #41 