### PR TITLE
Revert "enable Travis-CI building/testing on osx"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ after_success:
   # generate code coverage report
   - mvn -B -e -fae -Ptravis-ci clean verify jacoco:report coveralls:report
 
-#jdk:
-#  - openjdk7
-#  - oraclejdk7
-#  - oraclejdk8
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8
 
 os:
   - linux
-  - osx
+  # - osx
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Reverts GeoDienstenCentrum/sass-maven-plugin#16

until we get build fixed;

```
Using worker: saucelabs-mac-1.worker.travis-ci.org:travis-mac_osx-7
system_info
Build system information
Build language: java
git.checkout
5.00s$ git clone --depth=50 --branch=master git://github.com/GeoDienstenCentrum/sass-maven-plugin.git GeoDienstenCentrum/sass-maven-plugin
Cloning into 'GeoDienstenCentrum/sass-maven-plugin'...
remote: Counting objects: 550, done.
remote: Compressing objects: 100% (210/210), done.
remote: Total 550 (delta 226), reused 538 (delta 222)
Receiving objects: 100% (550/550), 103.59 KiB | 0 bytes/s, done.
Resolving deltas: 100% (226/226), done.
Checking connectivity... done.
$ cd GeoDienstenCentrum/sass-maven-plugin
$ git checkout -qf f2836cd1be912a4b9686c178bfaa4e3ea4dbb175
Setting environment variables from repository settings
$ export repoToken=[secure]
$ java -version
java version "1.7.0_45"
Java(TM) SE Runtime Environment (build 1.7.0_45-b18)
Java HotSpot(TM) 64-Bit Server VM (build 24.45-b08, mixed mode)
$ javac -version
javac 1.7.0_45
0.00s$ mvn install -U -Dmaven.test.skip=true -B -V -fae -q -T2
Error: JAVA_HOME is not defined correctly.
  We cannot execute /usr/libexec/java_home/bin/java
The command "mvn install -U -Dmaven.test.skip=true -B -V -fae -q -T2" failed and exited with 1 during .
Your build has been stopped.
```