### PR TITLE
update scss-lint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
 		<sass.version>3.4.13</sass.version>
 		<jruby.version>1.7.19</jruby.version>
 		<maven.version>3.2.5</maven.version>
-		<scss-lint.version>0.34.0</scss-lint.version>
+		<scss-lint.version>0.35.0</scss-lint.version>
 		<debug>true</debug>
 		<github.username />
 		<github.password />

--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -25,6 +25,10 @@ ${project.name} ${project.version} Release Notes
   running on JRuby ${project.properties.get("jruby.version")}.
   Please check the {{{${project.artifactId}/dependencies.html#provided}full dependencies}} to find out about the
   specific Sass and other transitive dependencies included in this release.
+  
+** Fix
+
+  * Use the latest version of the ffi gems which had serious bugs in the last release
 
 ** New
 
@@ -33,6 +37,8 @@ ${project.name} ${project.version} Release Notes
   []
 
 ** Enhancements
+
+  * Update scss-lint to version ${project.properties.get("scss-lint.version")}
 
   * Update Sass to version ${project.properties.get("sass.version")}
 


### PR DESCRIPTION
 - [x] [v0.35.0 was released](https://github.com/causes/scss-lint/releases/tag/v0.35.0) on March 20