### PR TITLE
Add a -Dfailsafe.useFile=false option for the verify phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 
 script:
   # execute unit and integration tests
-  - mvn -e verify -B
+  - mvn -e -fae -B -Dfailsafe.useFile=false -T2 clean test verify
 
 after_success:
   # generate code coverage report

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ build: off
 
 test_script:
   - cd C:\projects\sass-maven-plugin
-  - mvn -e -DWatchMojoTestSleeptime=90000 test verify -fae -B
+  - mvn -e -fae -B -DWatchMojoTestSleeptime=90000 -Dfailsafe.useFile=false -T2 clean test verify
 
 environment:
   MVN_VERSION: 3.3.1

--- a/pom.xml
+++ b/pom.xml
@@ -826,7 +826,7 @@
 					<plugin>
 						<groupId>org.sonatype.plugins</groupId>
 						<artifactId>nexus-staging-maven-plugin</artifactId>
-						<version>1.6.5</version>
+						<version>1.6.6</version>
 						<extensions>true</extensions>
 						<configuration>
 							<serverId>ossrh</serverId>


### PR DESCRIPTION
So we may see the integration test output in the logs.