### PR TITLE
upgrade JRuby to 9.0.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<compass.version>1.0.3</compass.version>
 		<sass.version>3.4.18</sass.version>
-		<jruby.version>9.0.0.0</jruby.version>
+		<jruby.version>9.0.1.0</jruby.version>
 		<maven-libs.version>3.3.3</maven-libs.version>
 		<scss-lint.version>0.41.0</scss-lint.version>
 		<bourbon.version>4.2.4</bourbon.version>
@@ -774,7 +774,7 @@
 					<plugin>
 						<groupId>org.eluder.coveralls</groupId>
 						<artifactId>coveralls-maven-plugin</artifactId>
-						<version>3.2.0</version>
+						<version>4.0.0</version>
 						<configuration>
 							<jacocoReports>
 								<file>${project.build.directory}/site/jacoco/jacoco.xml</file>

--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -31,12 +31,34 @@ ${project.name} ${project.version} Release Notes
   to find out about the specific Sass and other transitive dependencies
   included in this release.
 
-** New
+~~ ** New
 
 ~~   *
 
 ~~  []
 
+
+** Enhancements and Fixes
+
+~~  * Update Sass to version ${project.properties.get("sass.version")}, please check
+~~    the {{{http://sass-lang.com/documentation/file.SASS_CHANGELOG.html}Sass changelog}}
+
+~~  * Update SCSS-Lint to version ${project.properties.get("scss-lint.version")}, please check
+~~    the {{{https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md}SCSS-Lint changelog}}
+
+~~  * Update Compass to version ${project.properties.get("compass.version")}
+
+  * Update JRuby to ${project.properties.get("jruby.version")}
+
+  []
+
+* 2.12 Release Notes
+
+  A complete list of issues can be seen in the tracker
+  {{{${project.issueManagement.url}?q=milestone%3A$2.12+is%3Aclosed}milestone 2.12}}.
+
+  This release features Compass version 1.0.3, Bourbon version 4.2.4 and Sass version 3.4.18 
+  running on JRuby 9.0.0.0.
 
 ** Enhancements and Fixes
 
@@ -46,11 +68,7 @@ ${project.name} ${project.version} Release Notes
   * Update SCSS-Lint to version ${project.properties.get("scss-lint.version")}, please check
     the {{{https://github.com/brigade/scss-lint/blob/master/CHANGELOG.md}SCSS-Lint changelog}}
 
-~~  * Update Compass to version ${project.properties.get("compass.version")}
-
-~~  * Update JRuby to ${project.properties.get("jruby.version")}
-
-~~  []
+  []
 
 * 2.11 Release Notes
 


### PR DESCRIPTION
also updates the coveralls-maven-plugin and release notes