### PR TITLE
osx Maven update for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ language: java
 sudo: false
 
 before_install:
-   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
+   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+         brew update;
+         brew upgrade maven;
+         export JAVA_HOME=$(/usr/libexec/java_home);
+     fi
+   #- if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
    - echo $JAVA_HOME
 
 install:
@@ -37,5 +42,7 @@ matrix:
 #      env: JAVA_HOME=/usr/libexec/java_home
 
 cache:
+  brew: true
   directories:
   - $HOME/.m2
+  #- /Library/Caches/Homebrew

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,13 @@ sudo: false
 
 before_install:
    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-         brew update;
+         brew update --quiet;
          brew upgrade maven;
-         export JAVA_HOME=$(/usr/libexec/java_home);
      fi
-   #- if [ "$TRAVIS_OS_NAME" == "osx" ]; then export JAVA_HOME=$(/usr/libexec/java_home); fi
+   - if [ "$TRAVIS_OS_NAME" == "osx" ] && [ "$JVM" == "latest" ]; then
+         brew tap caskroom/cask;
+         brew install Caskroom/cask/java;
+     fi
    - echo $JAVA_HOME
 
 install:
@@ -35,7 +37,9 @@ matrix:
       jdk: openjdk7
     - os: linux
       jdk: oraclejdk8
-# this is the current Travis default JDK on linux
+    - os: osx
+      env: JVM=latest
+# these are the current Travis default JDKs on linux/osx
 #    - os: linux
 #      jdk: oraclejdk7
 #    - os: osx

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 	<contributors />
 	<mailingLists />
 	<prerequisites>
-		<maven>3.2</maven>
+		<maven>3.2.5</maven>
 	</prerequisites>
 	<scm>
 		<connection>scm:git:git://github.com/GeoDienstenCentrum/${project.artifactId}.git</connection>

--- a/src/site/apt/releasenotes.apt.vm
+++ b/src/site/apt/releasenotes.apt.vm
@@ -40,6 +40,8 @@ ${project.name} ${project.version} Release Notes
 
 ** Enhancements and Fixes
 
+   * The minimum required version has been updated to ${project.prerequisites.maven}
+
 ~~  * Update Sass to version ${project.properties.get("sass.version")}, please check
 ~~    the {{{http://sass-lang.com/documentation/file.SASS_CHANGELOG.html}Sass changelog}}
 
@@ -57,8 +59,8 @@ ${project.name} ${project.version} Release Notes
 
 * 2.14 Release Notes
 
-  This release features Compass version 1.0.3, Bourbon version 4.2.6 and Sass version 3.4.19 
-  running on JRuby 9.0.4.0. 
+  This release features Compass version 1.0.3, Bourbon version 4.2.6 and Sass version 3.4.19
+  running on JRuby 9.0.4.0.
 
   A complete list of issues can be seen in the tracker
   {{{${project.issueManagement.url}?q=milestone%3A$2.14+is%3Aclosed}milestone 2.14}}.


### PR DESCRIPTION
This updates Maven on osx images to run the latest version.
Also sets the minimum requirement for Maven to 3.2.5

close travis-ci/travis-ci#5170