### PR TITLE
Use JRuby directly instead of ScriptEngineManager

### DIFF
--- a/src/main/java/nl/geodienstencentrum/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/nl/geodienstencentrum/maven/plugin/sass/AbstractSassMojo.java
@@ -37,11 +37,6 @@ import java.util.Map.Entry;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-
 import org.apache.commons.io.FilenameUtils;
 import org.apache.maven.model.FileSet;
 import org.apache.maven.plugin.AbstractMojo;


### PR DESCRIPTION
Using JRuby directly instead of using it through the Java
ScriptEngineManager in order to allow usage of the plugin in environments
with a JRUBY_HOME set.

close #92 