### PR TITLE
use string for Gem.paths

### DIFF
--- a/src/main/java/nl/geodienstencentrum/maven/plugin/sass/AbstractSassMojo.java
+++ b/src/main/java/nl/geodienstencentrum/maven/plugin/sass/AbstractSassMojo.java
@@ -305,7 +305,7 @@ public abstract class AbstractSassMojo extends AbstractMojo {
 			}
 			/* remove trailing comma+\n */
 			sassScript.setLength(sassScript.length() - 2);
-			sassScript.append("\n] }\n");
+			sassScript.append("\n].uniq.join(File::PATH_SEPARATOR) }\n");
 			sassScript.append("Gem.paths = env\n");
 		}
 


### PR DESCRIPTION
quick fix for the deprecation message coming from `Gem.paths`, this should be cleaned up; there's a round trip of splitting into array in java and then unsplitting the array in ruby...

close #117