### PR TITLE
Windows builds on Java 11

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
 
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+    - JAVA_HOME: C:\Program Files\Java\jdk11
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Stop using 32bits Java 8 for tests and start using Java 11